### PR TITLE
Cowork plugin + .mcpb desktop extension + release automation

### DIFF
--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -93,11 +93,34 @@ jobs:
                   except json.JSONDecodeError as e:
                       failures.append(f"{name}: {hooks} invalid JSON: {e}")
 
+          # Desktop extension (.mcpb) is keyed to the pywry plugin specifically
+          desktop_manifest = repo / "claude" / "desktop-extension" / "manifest.json"
+          pywry_entry = next((p for p in plugins if p.get("name") == "pywry"), None)
+          if pywry_entry is not None and desktop_manifest.exists():
+              try:
+                  dm = json.loads(desktop_manifest.read_text(encoding="utf-8"))
+              except json.JSONDecodeError as e:
+                  failures.append(f"{desktop_manifest}: invalid JSON: {e}")
+              else:
+                  if dm.get("version") != pywry_entry.get("version"):
+                      failures.append(
+                          f"desktop-extension/manifest.json version "
+                          f"{dm.get('version')!r} != pywry plugin "
+                          f"{pywry_entry.get('version')!r}"
+                      )
+                  if dm.get("name") != "pywry":
+                      failures.append(
+                          f"desktop-extension/manifest.json name "
+                          f"{dm.get('name')!r} != 'pywry'"
+                      )
+          elif pywry_entry is not None and not desktop_manifest.exists():
+              failures.append(f"missing {desktop_manifest}")
+
           if failures:
               for f in failures:
                   print(f"::error::{f}")
               sys.exit(1)
-          print(f"ok — {len(plugins)} plugin(s) validated")
+          print(f"ok — {len(plugins)} plugin(s) validated, .mcpb manifest in sync")
           PY
 
       - name: Check CHANGELOG was updated when plugin.json version changes

--- a/.github/workflows/release-claude-artifacts.yml
+++ b/.github/workflows/release-claude-artifacts.yml
@@ -1,0 +1,108 @@
+name: Release Claude artifacts
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-claude-artifacts
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag and release on version bump
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read plugin version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r .version claude/plugins/pywry/.claude-plugin/plugin.json)
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=claude-pywry-v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Plugin version: $VERSION"
+
+      - name: Skip if tag already exists
+        id: tag_check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG"; then
+            echo "Tag $TAG already published — nothing to release."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG missing — will build and release."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build distributions (enforces version sync across all three manifests)
+        if: steps.tag_check.outputs.exists == 'false'
+        run: python claude/scripts/build_distributions.py
+
+      - name: Extract changelog section
+        id: notes
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          python3 - "$VERSION" > "$NOTES_FILE" <<'PY'
+          import re
+          import sys
+
+          version = sys.argv[1]
+          text = open("claude/plugins/pywry/CHANGELOG.md", encoding="utf-8").read()
+          # Match either "## 1.2.3" or "## [1.2.3]" headings
+          pattern = re.compile(
+              rf"^## \[?{re.escape(version)}\]?[^\n]*\n(.*?)(?=^## |\Z)",
+              re.MULTILINE | re.DOTALL,
+          )
+          m = pattern.search(text)
+          if m:
+              print(m.group(1).strip())
+          else:
+              print("See [CHANGELOG.md](claude/plugins/pywry/CHANGELOG.md) for details.")
+          PY
+          echo "file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.tag_check.outputs.exists == 'false'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag and create GitHub release
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.value }}
+          NOTES_FILE: ${{ steps.notes.outputs.file }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git tag -a "$TAG" -m "pywry plugin v$VERSION" "$GITHUB_SHA"
+          git push origin "$TAG"
+          gh release create "$TAG" \
+            --title "pywry plugin v$VERSION" \
+            --notes-file "$NOTES_FILE" \
+            claude/dist/pywry-cowork.plugin \
+            claude/dist/pywry.mcpb

--- a/claude/CONTRIBUTING.md
+++ b/claude/CONTRIBUTING.md
@@ -48,10 +48,10 @@ summary below:
    `Release claude/plugins/pywry v0.2.0`.
 5. Tag:
    ```bash
-   git tag -a plugin-pywry-v0.2.0 -m "pywry plugin v0.2.0"
-   git push origin plugin-pywry-v0.2.0
+   git tag -a claude-pywry-v0.2.0 -m "pywry plugin v0.2.0"
+   git push origin claude-pywry-v0.2.0
    ```
-6. Users pin with `/plugin install pywry@pywry --version plugin-pywry-v0.2.0`
+6. Users pin with `/plugin install pywry@pywry --version claude-pywry-v0.2.0`
    to avoid tracking `main`.
 
 ## Adding a new plugin

--- a/claude/README.md
+++ b/claude/README.md
@@ -11,7 +11,7 @@ claude/
 ├── .claude-plugin/
 │   └── marketplace.json         # Single marketplace, lists every plugin below
 ├── plugins/
-│   └── pywry/                   # The canonical PyWry plugin
+│   └── pywry/                   # The canonical PyWry plugin (Claude Code)
 │       ├── .claude-plugin/plugin.json
 │       ├── .mcp.json            # Declares the `pywry` MCP server
 │       ├── agents/              # `pywry-builder` subagent
@@ -20,15 +20,50 @@ claude/
 │       ├── skills/              # pywry-orientation skill
 │       ├── CHANGELOG.md
 │       └── README.md
+├── desktop-extension/           # Claude Desktop MCP Bundle (.mcpb) source
+│   ├── manifest.json            # MCPB manifest (different schema from plugin.json)
+│   ├── pyproject.toml           # uv-runtime dependency spec → pywry[mcp]
+│   ├── src/server.py            # Re-enters pywry.mcp.__main__:main
+│   └── README.md
+├── scripts/
+│   └── build_distributions.py   # Builds dist/pywry-cowork.plugin and dist/pywry.mcpb
+├── dist/                        # Build output (gitignored)
 ├── CONTRIBUTING.md              # How to add / maintain plugins here
 └── README.md                    # (this file)
 ```
+
+`claude/plugins/pywry/` is the single source of truth. The Cowork
+`.plugin` is a build-time transform of it (with `.mcp.json` and
+`hooks/` stripped); both are produced by
+[`scripts/build_distributions.py`](scripts/build_distributions.py).
 
 Adding a sibling plugin later is a file-system operation: create
 `claude/plugins/<name>/`, add a `plugin.json`, and append an entry to
 `claude/.claude-plugin/marketplace.json`.
 
-## Installing the plugin
+## Distribution variants
+
+PyWry ships into three Claude surfaces from this directory:
+
+| Variant | Artifact | Where it lives | Install path |
+|---|---|---|---|
+| Claude Code plugin | `claude/plugins/pywry/` (directory) | GitHub marketplace, PyPI-bundled wheel, local worktree | `/plugin marketplace add deeleeramone/PyWry --path claude/.claude-plugin/marketplace.json` then `/plugin install pywry@pywry` |
+| Cowork plugin | `claude/dist/pywry-cowork.plugin` (zip) | GitHub release asset; org marketplace upload | Cowork → Customize → Plugins → Upload plugin |
+| Claude Desktop extension | `claude/dist/pywry.mcpb` (zip) | GitHub release asset | Open the `.mcpb` file in Claude Desktop |
+
+Build the two zipped artifacts with:
+
+```bash
+python claude/scripts/build_distributions.py
+```
+
+The Cowork variant intentionally drops `.mcp.json` and `hooks/`
+because Cowork's hosted sandbox cannot launch the local `pywry` CLI;
+skills, slash commands, and the `pywry-builder` subagent still work.
+The `.mcpb` ships only the MCP server (Claude Desktop has no concept
+of slash commands or subagents).
+
+## Installing the Claude Code plugin
 
 ### From GitHub (primary path)
 

--- a/claude/desktop-extension/README.md
+++ b/claude/desktop-extension/README.md
@@ -1,0 +1,36 @@
+# pywry — Claude Desktop extension (`.mcpb`)
+
+Native [Claude Desktop](https://claude.ai/download) integration for
+[PyWry](https://github.com/deeleeramone/PyWry). Same 66+ MCP tools as
+the Claude Code plugin, packaged as an [MCP Bundle](https://github.com/anthropics/dxt)
+so Claude Desktop installs and runs it without any manual `pip` step.
+
+## Install
+
+1. Grab `pywry.mcpb` from the latest GitHub release (or run
+   `python scripts/build_distributions.py` from the repo root to build
+   it locally).
+2. Open the file. Claude Desktop will show an install dialog —
+   confirm to add the extension.
+3. The `uv` runtime resolves `pywry[mcp]>=2.0.0` from PyPI on first
+   launch. Subsequent launches reuse the cached environment.
+
+## Verify
+
+Open a Claude Desktop conversation and ask: *"List the pywry MCP
+tools."* Claude should enumerate the `create_widget`, `show_plotly`,
+`show_dataframe`, `show_tvchart`, `tvchart_*`, and `create_chat_widget`
+families.
+
+## Differences from the Claude Code plugin
+
+This extension ships the **MCP server only**. Slash commands
+(`/pywry:doctor`, `/pywry:scaffold`, `/pywry:examples`), the
+`pywry-builder` subagent, the `pywry-orientation` skill, and the
+`ruff format` PostToolUse hook are Claude Code surfaces and are not
+expressible in the `.mcpb` format — install [the Claude Code plugin](../plugins/pywry/README.md)
+if you want those.
+
+## License
+
+Apache-2.0, same as PyWry.

--- a/claude/desktop-extension/manifest.json
+++ b/claude/desktop-extension/manifest.json
@@ -1,0 +1,56 @@
+{
+  "manifest_version": "0.4",
+  "name": "pywry",
+  "display_name": "PyWry",
+  "version": "0.1.0",
+  "description": "Native Claude Desktop integration for PyWry — MCP tools for generating and rendering HTML components, chat artifacts, and building native, web, or Jupyter applications with live preview. Built-in support for AgGrid, Plotly, TradingView, and more.",
+  "long_description": "PyWry is a cross-platform rendering engine and desktop UI toolkit for Python. This Desktop Extension bundles the PyWry MCP server (66+ tools) so Claude Desktop can scaffold widgets, render Plotly charts, drive AG Grid tables, build TradingView lightweight charts, and produce streaming chat artifacts — all delivered as embedded HTML resources viewable directly in the artifact pane. The `uv` runtime resolves `pywry[mcp]` from PyPI on first launch; no manual `pip install` is required.",
+  "author": {
+    "name": "PyWry",
+    "email": "pywry2@gmail.com",
+    "url": "https://github.com/deeleeramone/PyWry"
+  },
+  "homepage": "https://github.com/deeleeramone/PyWry",
+  "documentation": "https://github.com/deeleeramone/PyWry",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deeleeramone/PyWry.git"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "pywry",
+    "webview",
+    "tauri",
+    "plotly",
+    "tradingview",
+    "aggrid",
+    "dashboard",
+    "charting",
+    "visualization",
+    "data-science",
+    "finance",
+    "interactive",
+    "real-time",
+    "chat",
+    "llm",
+    "agent",
+    "artifact",
+    "jupyter",
+    "notebook",
+    "python",
+    "mcp"
+  ],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/server.py"
+  },
+  "tools_generated": true,
+  "prompts_generated": true,
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.10"
+    }
+  }
+}

--- a/claude/desktop-extension/pyproject.toml
+++ b/claude/desktop-extension/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "pywry-desktop-extension"
+version = "0.1.0"
+description = "PyWry MCP Bundle (.mcpb) for Claude Desktop. Wraps pywry[mcp] so the uv runtime resolves dependencies automatically."
+requires-python = ">=3.10"
+dependencies = [
+  "pywry[mcp]>=2.0.0",
+]

--- a/claude/desktop-extension/src/server.py
+++ b/claude/desktop-extension/src/server.py
@@ -1,0 +1,16 @@
+"""Entry point for the PyWry MCP Bundle (.mcpb) loaded by Claude Desktop.
+
+Claude Desktop's `uv` runtime resolves `pywry[mcp]` from the bundled
+`pyproject.toml`, then invokes this file. We re-enter the existing
+`pywry.mcp.__main__:main` so all 66+ tools, resources, and skill
+loaders stay in a single source tree.
+"""
+
+import sys
+
+from pywry.mcp.__main__ import main
+
+
+if __name__ == "__main__":
+    sys.argv = ["pywry-mcp", "--transport", "stdio"]
+    main()

--- a/claude/plugins/pywry/RELEASING.md
+++ b/claude/plugins/pywry/RELEASING.md
@@ -12,15 +12,18 @@ Summary:
 - Minor: new command / skill / agent / hook / MCP tool.
 - Major: rename, remove, breaking contract change.
 
-## 2. Update the version in both manifests
+## 2. Update the version in all three manifests
 
 Edit:
 
 1. [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) → `"version": "…"`
 2. [`claude/.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
    → `plugins[name=pywry].version`
+3. [`claude/desktop-extension/manifest.json`](../../desktop-extension/manifest.json)
+   → `"version": "…"`
 
-Both must match. CI enforces this.
+All three must match. `claude/scripts/build_distributions.py` fails fast
+on drift, and CI enforces it.
 
 ## 3. Update the changelog
 
@@ -32,44 +35,56 @@ Edit [CHANGELOG.md](CHANGELOG.md):
 - Keep sub-headers (`### Added`, `### Changed`, `### Fixed`,
   `### Removed`, `### Documentation`).
 
-## 4. Commit
+## 4. Commit and merge to main
 
 ```bash
 git add claude/plugins/pywry/.claude-plugin/plugin.json \
         claude/.claude-plugin/marketplace.json \
+        claude/desktop-extension/manifest.json \
         claude/plugins/pywry/CHANGELOG.md
 git commit -m "Release claude/plugins/pywry v<version>"
 ```
 
-## 5. Tag
+Open a PR, get it merged to `main`. That's the last manual step.
 
-```bash
-git tag -a plugin-pywry-v<version> -m "pywry plugin v<version>"
-git push origin main plugin-pywry-v<version>
-```
+## 5. Automatic: tag, build, and release
 
-Tag prefix `plugin-pywry-v` keeps these distinct from PyWry Python
+Once the version-bump commit lands on `main`,
+[`.github/workflows/release-claude-artifacts.yml`](../../../.github/workflows/release-claude-artifacts.yml)
+runs and:
+
+1. Reads the new version from `plugin.json`.
+2. Skips if `claude-pywry-v<version>` already exists (idempotent).
+3. Runs `claude/scripts/build_distributions.py` (which re-verifies
+   that all three manifests are in sync — fails the workflow if not).
+4. Tags the merge commit `claude-pywry-v<version>`.
+5. Creates the GitHub release with the changelog section as notes
+   and `pywry-cowork.plugin` + `pywry.mcpb` attached.
+
+Tag prefix `claude-pywry-v` keeps these distinct from PyWry Python
 package tags (`v2.0.0` etc.), so releases in the two trees don't
 collide.
 
-## 6. (Optional) Draft a GitHub release
+To run the build locally before opening the PR:
 
 ```bash
-gh release create plugin-pywry-v<version> \
-  --title "pywry plugin v<version>" \
-  --notes-file <(sed -n "/## \[<version>\]/,/## \[/p" claude/plugins/pywry/CHANGELOG.md | head -n -1)
+python claude/scripts/build_distributions.py
 ```
 
-## 7. Announce
+To re-run the release (e.g. after a transient failure), trigger
+`Release Claude artifacts` via `workflow_dispatch` from the Actions
+tab — the tag-existence check makes it safe to repeat.
+
+## 6. Announce
 
 Post the install command to the relevant channels:
 
 ```
 /plugin marketplace add deeleeramone/PyWry --path claude/.claude-plugin/marketplace.json
-/plugin install pywry@pywry --version plugin-pywry-v<version>
+/plugin install pywry@pywry --version claude-pywry-v<version>
 ```
 
-## 8. Verify
+## 7. Verify
 
 In a fresh Claude Code session:
 

--- a/claude/scripts/build_distributions.py
+++ b/claude/scripts/build_distributions.py
@@ -1,0 +1,167 @@
+"""Build PyWry distribution artifacts for Cowork and Claude Desktop.
+
+Produces, in ``dist/``:
+
+* ``pywry-cowork.plugin`` — Cowork plugin (zip of ``claude/plugins/pywry/``
+  with ``.mcp.json`` and ``hooks/`` stripped, since Cowork's hosted sandbox
+  cannot launch the local ``pywry`` CLI).
+* ``pywry.mcpb`` — Claude Desktop extension (zip of
+  ``claude/desktop-extension/`` with ``manifest.json`` at root).
+
+Run with the project Python: ``python claude/scripts/build_distributions.py``.
+Stdlib only — no external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+CLAUDE_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = CLAUDE_DIR.parent
+PLUGIN_SRC = CLAUDE_DIR / "plugins" / "pywry"
+DESKTOP_SRC = CLAUDE_DIR / "desktop-extension"
+MARKETPLACE_JSON = CLAUDE_DIR / ".claude-plugin" / "marketplace.json"
+PLUGIN_JSON = PLUGIN_SRC / ".claude-plugin" / "plugin.json"
+MANIFEST_JSON = DESKTOP_SRC / "manifest.json"
+DIST = CLAUDE_DIR / "dist"
+
+SIZE_LIMIT_BYTES = 50 * 1024 * 1024
+EXCLUDE_DIR_NAMES = {
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    "node_modules",
+    ".git",
+}
+EXCLUDE_FILE_NAMES = {".DS_Store"}
+EXCLUDE_SUFFIXES = {".pyc", ".pyo"}
+
+COWORK_DESCRIPTION_SUFFIX = (
+    " (Cowork edition — skills + commands + agent only; "
+    "for full MCP integration use the Claude Code plugin)"
+)
+
+
+def _is_excluded(path: Path) -> bool:
+    if any(part in EXCLUDE_DIR_NAMES for part in path.parts):
+        return True
+    if path.name in EXCLUDE_FILE_NAMES:
+        return True
+    if path.suffix in EXCLUDE_SUFFIXES:
+        return True
+    return False
+
+
+def _check_versions_in_sync() -> str:
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    marketplace = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
+    manifest = json.loads(MANIFEST_JSON.read_text(encoding="utf-8"))
+
+    v_plugin = plugin["version"]
+    v_manifest = manifest["version"]
+    v_marketplace = next(
+        (p["version"] for p in marketplace["plugins"] if p["name"] == "pywry"),
+        None,
+    )
+    if v_marketplace is None:
+        raise RuntimeError(
+            f"'pywry' entry not found in {MARKETPLACE_JSON.relative_to(REPO_ROOT)}"
+        )
+
+    if not (v_plugin == v_marketplace == v_manifest):
+        raise RuntimeError(
+            "Version drift detected — all three must match before building:\n"
+            f"  {PLUGIN_JSON.relative_to(REPO_ROOT)}: {v_plugin}\n"
+            f"  {MARKETPLACE_JSON.relative_to(REPO_ROOT)}: {v_marketplace}\n"
+            f"  {MANIFEST_JSON.relative_to(REPO_ROOT)}: {v_manifest}"
+        )
+    return v_plugin
+
+
+def _zip_directory(src: Path, out: Path) -> None:
+    if out.exists():
+        out.unlink()
+    with zipfile.ZipFile(out, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(src.rglob("*")):
+            if _is_excluded(path) or not path.is_file():
+                continue
+            arcname = path.relative_to(src).as_posix()
+            zf.write(path, arcname)
+
+
+def _build_cowork_plugin() -> Path:
+    workdir = DIST / "_cowork_staging"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    for src in PLUGIN_SRC.rglob("*"):
+        if _is_excluded(src):
+            continue
+        rel = src.relative_to(PLUGIN_SRC)
+        if rel == Path(".mcp.json"):
+            continue
+        if rel.parts and rel.parts[0] == "hooks":
+            continue
+        dst = workdir / rel
+        if src.is_dir():
+            dst.mkdir(parents=True, exist_ok=True)
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+    plugin_json_path = workdir / ".claude-plugin" / "plugin.json"
+    plugin = json.loads(plugin_json_path.read_text(encoding="utf-8"))
+    if not plugin["description"].endswith(COWORK_DESCRIPTION_SUFFIX):
+        plugin["description"] += COWORK_DESCRIPTION_SUFFIX
+    plugin_json_path.write_text(
+        json.dumps(plugin, indent=2) + "\n", encoding="utf-8"
+    )
+
+    out = DIST / "pywry-cowork.plugin"
+    _zip_directory(workdir, out)
+    shutil.rmtree(workdir)
+    return out
+
+
+def _build_desktop_extension() -> Path:
+    out = DIST / "pywry.mcpb"
+    _zip_directory(DESKTOP_SRC, out)
+    return out
+
+
+def _summarize(path: Path) -> None:
+    size = path.stat().st_size
+    if size > SIZE_LIMIT_BYTES:
+        raise RuntimeError(
+            f"{path.name} is {size:,} bytes — exceeds the 50 MB limit"
+        )
+    with zipfile.ZipFile(path) as zf:
+        files = zf.namelist()
+    rel = path.relative_to(REPO_ROOT)
+    print(f"  {rel} — {size:,} bytes, {len(files)} files")
+
+
+def main() -> int:
+    DIST.mkdir(exist_ok=True)
+    version = _check_versions_in_sync()
+    print(f"Building PyWry distributions at version {version}")
+
+    cowork = _build_cowork_plugin()
+    desktop = _build_desktop_extension()
+
+    print("\nArtifacts:")
+    _summarize(cowork)
+    _summarize(desktop)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pywry/docs/docs/mcp/plugin.md
+++ b/pywry/docs/docs/mcp/plugin.md
@@ -36,7 +36,7 @@ launches the `pywry` console script installed by pip.
 Pin to a specific release:
 
 ```
-/plugin install pywry@pywry --version plugin-pywry-v0.1.0
+/plugin install pywry@pywry --version claude-pywry-v0.1.0
 ```
 
 Without a version, the install tracks `main`.

--- a/pywry/docs/requirements.txt
+++ b/pywry/docs/requirements.txt
@@ -9,7 +9,7 @@ griffe>=1.0.0
 
 # For cross-references
 mkdocs-gen-files>=0.5.0
-mkdocs-literate-nav>=0.6.0
+mkdocs-literate-nav>=0.6.3
 mkdocs-section-index>=0.3.0
 
 # Needed for building docs (dependencies of pywry)

--- a/pywry/docs/requirements.txt
+++ b/pywry/docs/requirements.txt
@@ -5,7 +5,7 @@ mkdocs-autorefs>=1.0.0
 
 # Auto-generated API documentation from source
 mkdocstrings[python]>=0.26.0
-griffe>=1.0.0
+griffe>=2.0.2
 
 # For cross-references
 mkdocs-gen-files>=0.5.0

--- a/pywry/docs/requirements.txt
+++ b/pywry/docs/requirements.txt
@@ -8,7 +8,7 @@ mkdocstrings[python]>=1.0.4
 griffe>=2.0.2
 
 # For cross-references
-mkdocs-gen-files>=0.5.0
+mkdocs-gen-files>=0.6.1
 mkdocs-literate-nav>=0.6.3
 mkdocs-section-index>=0.3.12
 

--- a/pywry/docs/requirements.txt
+++ b/pywry/docs/requirements.txt
@@ -4,7 +4,7 @@ mkdocs-material>=9.5.0
 mkdocs-autorefs>=1.0.0
 
 # Auto-generated API documentation from source
-mkdocstrings[python]>=0.26.0
+mkdocstrings[python]>=1.0.4
 griffe>=2.0.2
 
 # For cross-references

--- a/pywry/docs/requirements.txt
+++ b/pywry/docs/requirements.txt
@@ -10,7 +10,7 @@ griffe>=2.0.2
 # For cross-references
 mkdocs-gen-files>=0.5.0
 mkdocs-literate-nav>=0.6.3
-mkdocs-section-index>=0.3.0
+mkdocs-section-index>=0.3.12
 
 # Needed for building docs (dependencies of pywry)
 pydantic>=2.0


### PR DESCRIPTION
## Summary

- Builds two new artifacts from the existing `claude/plugins/pywry/` source: `pywry-cowork.plugin` (stripped of `.mcp.json` + `hooks/` for Cowork's hosted sandbox) and `pywry.mcpb` (Claude Desktop MCP Bundle whose `uv` runtime resolves `pywry[mcp]` from PyPI).
- New `release-claude-artifacts.yml` workflow: on push to `main`, builds both artifacts and creates the `claude-pywry-v<version>` GitHub release if the tag doesn't yet exist (idempotent, safe to re-run via `workflow_dispatch`).
- Extends `plugin-manifest.yml` to validate the `.mcpb` manifest version stays in sync with the `pywry` entry in `marketplace.json`.